### PR TITLE
Enable kyverno with version 1.6.2, add PSS policies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Enable `kyverno` installation by default.
+- Update to Kyverno (app) version 0.10.0 containing upstream version 1.6.2.
+- Add `kyverno-policies` to the security pack for enforcing Kubernetes Pod Security Standards (PSS).
+
 ### Changed
 
 - Use Falco app version 0.3.2.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Enable `kyverno` installation by default.
 - Update to Kyverno (app) version 0.10.0 containing upstream version 1.6.2.
-- Add `kyverno-policies` to the security pack for enforcing Kubernetes Pod Security Standards (PSS).
+- Add `kyverno-policies` 0.17.1 to the security pack for enforcing Kubernetes Pod Security Standards (PSS).
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,23 @@
 [![CircleCI](https://circleci.com/gh/giantswarm/security-pack.svg?style=shield)](https://circleci.com/gh/giantswarm/security-pack)
 
-# security-pack chart
+# Giant Swarm Security Pack
 
-Giant Swarm offers a security-pack App which can be installed in workload clusters. This App is a convenient wrapper containing multiple other Apps composing our security pack.
+Giant Swarm offers a [managed security pack][security-pack] which provides an unintrusive baseline for security observability and enforcement in Kubernetes clusters. This App is a convenient wrapper containing multiple other Apps which make up the security pack.
 
-**Note:** There is a [known issue](https://github.com/kyverno/kyverno/issues/3111) when uninstalling `kyverno` which is pending upstream release. If installing `kyverno` through this App, you may need to manually Kyverno's `validatingwebhookconfigurations` and `mutatingwebhookconfigurations` if you subsequently uninstall the App prior to the 1.7.0 release.
+By default, installing the security pack in a cluster includes:
+
+- Falco, from our [`falco-app`][falco-app]
+- Kyverno, from our [`kyverno-app`][kyverno-app]
+  + our [`kyverno-policies`][kyverno-policies] app for Kubernetes Pod Security Standards (PSS)
+- Starboard, from our [`starboard-app`][starboard-app]
+  + our [`starboard-exporter`][starboard-exporter] for exposing metrics
+- Trivy, from our [`trivy-app`][trivy-app]
+
+Apps can be selectively enabled or disabled using the `enabled` setting for that app in the `security-pack` Helm values.
+
+More information and configuration options can be found in each app repository.
+
+**Note:** There is a known issue when uninstalling Kyverno where some resources may not be removed properly. The cause is still under investigation, but a [recent update](https://github.com/kyverno/kyverno/issues/3111) has improved the situation so that Kyverno's webhooks are properly removed, meaning the remnants are unnecessary but should otherwise have no negative effect on the cluster. If installing Kyverno through this App, you may need to manually remove some lingering Kyverno resources if you subsequently choose to remove Kyverno.
 
 ## Installing
 
@@ -101,3 +114,11 @@ metadata:
 ```
 
 See our [full reference page on how to configure applications](https://docs.giantswarm.io/app-platform/app-configuration/) for more details.
+
+[falco-app]: https://github.com/giantswarm/falco-app
+[kyverno-app]: https://github.com/giantswarm/kyverno-app
+[kyverno-policies]: https://github.com/giantswarm/kyverno-policies/
+[security-pack]: https://docs.giantswarm.io/app-platform/apps/security/
+[starboard-app]: https://github.com/giantswarm/starboard-app
+[starboard-exporter]: https://github.com/giantswarm/starboard-exporter/
+[trivy-app]: https://github.com/giantswarm/trivy-app/

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ By default, installing the security pack in a cluster includes:
 
 - Falco, from our [`falco-app`][falco-app]
 - Kyverno, from our [`kyverno-app`][kyverno-app]
-  + our [`kyverno-policies`][kyverno-policies] app for Kubernetes Pod Security Standards (PSS)
+  - our [`kyverno-policies`][kyverno-policies] app for Kubernetes Pod Security Standards (PSS)
 - Starboard, from our [`starboard-app`][starboard-app]
-  + our [`starboard-exporter`][starboard-exporter] for exposing metrics
+  - our [`starboard-exporter`][starboard-exporter] for exposing metrics
 - Trivy, from our [`trivy-app`][trivy-app]
 
 Apps can be selectively enabled or disabled using the `enabled` setting for that app in the `security-pack` Helm values.

--- a/helm/security-pack/values.yaml
+++ b/helm/security-pack/values.yaml
@@ -25,9 +25,19 @@ apps:
     appName: kyverno
     chartName: kyverno
     catalog: giantswarm
-    enabled: false
+    enabled: true
     namespace: security-pack
-    version: 0.9.1
+    version: 0.10.0
+
+  # Kyverno policies for Kubernetes Pod Security Standards (PSS)
+  # From: https://github.com/giantswarm/kyverno-policies/
+  kyverno-policies:
+    appName: kyverno-policies
+    chartName: kyverno-policies
+    catalog: giantswarm
+    enabled: true
+    namespace: security-pack
+    version: 0.17.0
 
   starboard:
     appName: starboard

--- a/helm/security-pack/values.yaml
+++ b/helm/security-pack/values.yaml
@@ -37,7 +37,7 @@ apps:
     catalog: giantswarm
     enabled: true
     namespace: security-pack
-    version: 0.17.0
+    version: 0.17.1
 
   starboard:
     appName: starboard

--- a/helm/security-pack/values.yaml
+++ b/helm/security-pack/values.yaml
@@ -5,6 +5,11 @@ organization: ""
 # using the structure shown below.
 
 # userConfig:
+#   kyverno-policies:
+#     configMap:
+#       values: |
+#         kyverno-policies:
+#           podSecurityStandard: restricted
 #   trivy:
 #     configMap:
 #       values: |

--- a/helm/security-pack/values.yaml
+++ b/helm/security-pack/values.yaml
@@ -29,7 +29,7 @@ apps:
     namespace: security-pack
     version: 0.10.0
 
-  # Kyverno policies for Kubernetes Pod Security Standards (PSS)
+  # Kyverno policies for Kubernetes Pod Security Standards (PSS).
   # From: https://github.com/giantswarm/kyverno-policies/
   kyverno-policies:
     appName: kyverno-policies


### PR DESCRIPTION
Enables kyverno installation via security pack and ships the new kyverno-policies app for PSS policies
