### PR TITLE
Add cluster label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Adding `cluster` flag to the `kgs` command generating App CR.
+
 ## [0.3.0] - 2022-05-17
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ kind: App
 metadata:
   labels:
     app-operator.giantswarm.io/version: 0.0.0
+    giantswarm.io/cluster: demo1
   name: security-pack
   namespace: demo1
 spec:

--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ The currently recommended way to install the security pack is:
     --catalog giantswarm \
     --name security-pack \
     --in-cluster \
-    --namespace demo1 \ 
+    --cluster demo1 \
+    --namespace demo1 \
     --version 0.0.1 \
     --user-configmap user-values.yaml > outerApp.yaml
     ```
@@ -57,7 +58,7 @@ Support for these methods are not yet officially supported, but may still work:
 1. [Using our web interface](https://docs.giantswarm.io/ui-api/web/app-platform/#installing-an-app)
 2. [Using our API](https://docs.giantswarm.io/api/#operation/createClusterAppV5)
 
-**Impoortant Note:** If you are not using `kubectl gs` plugin, plese remember to ensure the correct label: `app-operator.giantswarm.io/version: 0.0.0` is set on the App CR. Missing this configuration will result with stuck deployment of an app. 
+**Impoortant Note:** If you are not using `kubectl gs` plugin, plese remember to ensure the correct label: `app-operator.giantswarm.io/version: 0.0.0` is set on the App CR. Missing this configuration will result with stuck deployment of an app.
 
 ## Configuring
 


### PR DESCRIPTION
## Description

For the CAPx clusters we would like to delete all apps when the cluster is deleted, but apps are recognize by a cluster as belonging to it based on the `giantswarm.io/cluster` label. Technically, `security-pack` is a "unique" App CR (meaning it is reconciled by the unique `app-operator`) and as such do not necessarily need to carry this label itself, but without it, there is no way to pick it up upon cluster deletion.

Towards: https://github.com/giantswarm/cluster-apps-operator/pull/232 https://github.com/giantswarm/kubectl-gs/pull/816