### PR TITLE
Bump Jiralert version to 0.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Update to `starboard-exporter` version 0.5.0, adding support for exporting Starboard `CISKubeBenchReport` resources.
+- Update to `jiralert` version 0.0.3, adding support for autoresolving tickets.
 - Fix `Jiralert` catalog.
 
 ## [0.3.1] - 2022-06-10

--- a/helm/security-pack/values.yaml
+++ b/helm/security-pack/values.yaml
@@ -32,7 +32,7 @@ apps:
     catalog: giantswarm-playground
     enabled: false
     namespace: security-pack
-    version: 0.0.2
+    version: 0.0.3
 
   kyverno:
     appName: kyverno


### PR DESCRIPTION
This PR updates `Jiralert` to version 0.0.3

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
