### PR TITLE
Add trivy-operator option to pack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## Added
+
+- Enable optional installation of `trivy-operator`.
+
 ## [0.6.0] - 2022-08-17
 
 ### Changed

--- a/helm/security-pack/values.schema.json
+++ b/helm/security-pack/values.schema.json
@@ -165,6 +165,29 @@
                             "type": "string"
                         }
                     }
+                },
+                "trivyOperator": {
+                    "type": "object",
+                    "properties": {
+                        "appName": {
+                            "type": "string"
+                        },
+                        "catalog": {
+                            "type": "string"
+                        },
+                        "chartName": {
+                            "type": "string"
+                        },
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "namespace": {
+                            "type": "string"
+                        },
+                        "version": {
+                            "type": "string"
+                        }
+                    }
                 }
             }
         },

--- a/helm/security-pack/values.yaml
+++ b/helm/security-pack/values.yaml
@@ -40,7 +40,7 @@ apps:
     catalog: giantswarm
     enabled: true
     namespace: security-pack
-    version: 0.11.0
+    version: 0.11.1
 
   # Kyverno policies for Kubernetes Pod Security Standards (PSS).
   # From: https://github.com/giantswarm/kyverno-policies/

--- a/helm/security-pack/values.yaml
+++ b/helm/security-pack/values.yaml
@@ -56,7 +56,7 @@ apps:
     appName: starboard
     chartName: starboard-app
     catalog: giantswarm
-    enabled: false
+    enabled: true
     namespace: security-pack
     version: 0.8.0
 
@@ -80,6 +80,6 @@ apps:
     appName: trivy-operator
     chartName: trivy-operator
     catalog: giantswarm
-    enabled: true
+    enabled: false
     namespace: security-pack
     version: 0.1.0

--- a/helm/security-pack/values.yaml
+++ b/helm/security-pack/values.yaml
@@ -56,7 +56,7 @@ apps:
     appName: starboard
     chartName: starboard-app
     catalog: giantswarm
-    enabled: true
+    enabled: false
     namespace: security-pack
     version: 0.8.0
 
@@ -75,3 +75,11 @@ apps:
     enabled: true
     namespace: security-pack
     version: 0.4.0
+
+  trivyOperator:
+    appName: trivy-operator
+    chartName: trivy-operator
+    catalog: giantswarm
+    enabled: true
+    namespace: security-pack
+    version: 0.1.0


### PR DESCRIPTION
Adds optional support for installing `trivy-operator`, which is intended to replace `starboard`

Also bumps Kyverno to the latest version with some extra stability fixes

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` and `values.schema.json` are valid.
