### PR TITLE
Add icon for happa

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Add icon url to `Chart.yaml`
+
 ## [0.9.0] - 2022-11-10
 
 ### Changed

--- a/helm/security-pack/Chart.yaml
+++ b/helm/security-pack/Chart.yaml
@@ -1,6 +1,7 @@
 apiVersion: v2
 name: security-pack
 description: A Helm chart for Giant Swarm's collection of open-source security tools.
+icon: https://s.giantswarm.io/app-icons/giantswarm/1/dark.svg
 engine: gotpl
 home: https://github.com/giantswarm/security-pack
 sources:


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/1248



This PR:
- adds an icon URL to Chart.yaml for happa

Since this is a pack that contains multiple apps bundled by us, I think the giantswarm icon is appropriate. If you have another suggestion, feel free to propose it.
### Checklist

- [x] Update changelog in CHANGELOG.md.
