### PR TITLE
Add concurrency to automated chart update workflow

### DIFF
--- a/.github/workflows/automated_chart_update.yaml
+++ b/.github/workflows/automated_chart_update.yaml
@@ -14,6 +14,10 @@ on:
         required: true
         type: string
 
+concurrency:
+  group: update-chart-${{ github.event.client_payload.repo || inputs.repo }}
+  cancel-in-progress: true
+
 jobs:
   update_chart:
     name: Update chart reference


### PR DESCRIPTION
Avoids multiple commits for the same app to produce outdated results.