### PR TITLE
fix(values): Make Kyverno and Kyverno Policy Operator depend on Cilium.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Run the E2E test suites automatically on release PRs by adding `.github/release-pr-body.md`.
+- Values: Make Kyverno and Kyverno Policy Operator depend on Cilium.
 
 ## [2.2.0] - 2026-07-24
 

--- a/helm/security-bundle/values.yaml
+++ b/helm/security-bundle/values.yaml
@@ -98,6 +98,7 @@ apps:
     chartName: kyverno
     catalog: giantswarm
     dependsOn:
+      - cilium
       - kyverno-crds
       - prometheus-operator-crd
       - alloy-podlogs-crds
@@ -131,6 +132,7 @@ apps:
     chartName: kyverno-policy-operator
     catalog: giantswarm
     dependsOn:
+      - cilium
       - kyverno-crds
       - kyverno
       - alloy-podlogs-crds


### PR DESCRIPTION
Flux Helm Controller tries to install Kyverno while Cilium is not yet around or currently on its way. This makes the Kyverno HelmRelease fail. Kyverno Policy Operator depends on Kyverno, so theoretically we would not need to add Cilium as a dependency, but I'm rather safe than sorry as this could be subject to change in the future.